### PR TITLE
Inclusão da propriedade dataHoraVencimento no objeto Certificado!

### DIFF
--- a/src/main/java/br/com/swconsultoria/certificado/Certificado.java
+++ b/src/main/java/br/com/swconsultoria/certificado/Certificado.java
@@ -1,6 +1,7 @@
 package br.com.swconsultoria.certificado;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 /**
  *
@@ -26,6 +27,7 @@ public class Certificado {
 
 	private String nome;
 	private LocalDate vencimento;
+	private LocalDateTime dataHoraVencimento;
 	private Long diasRestantes;
 	private String arquivo;
 	private byte[] arquivoBytes;
@@ -104,6 +106,20 @@ public class Certificado {
 	 */
 	public void setVencimento(LocalDate vencimento) {
 		this.vencimento = vencimento;
+	}
+
+	/**
+	 * @return the dataHoraVencimento
+	 */
+	public LocalDateTime getDataHoraVencimento() {
+		return dataHoraVencimento;
+	}
+
+	/**
+	 * @param dataHoraVencimento the vencimento to set
+	 */
+	public void setDataHoraVencimento(LocalDateTime dataHoraVencimento) {
+		this.dataHoraVencimento = dataHoraVencimento;
 	}
 
 	/**

--- a/src/main/java/br/com/swconsultoria/certificado/CertificadoService.java
+++ b/src/main/java/br/com/swconsultoria/certificado/CertificadoService.java
@@ -15,6 +15,7 @@ import java.security.*;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
@@ -77,6 +78,7 @@ public class CertificadoService {
         certificado.setNome(aliasKey);
         certificado.setCnpjCpf(getDocumentoFromCertificado(certificado, keyStore));
         certificado.setVencimento(dataValidade(certificado).toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
+        certificado.setDataHoraVencimento(dataValidade(certificado).toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
         certificado.setDiasRestantes(diasRestantes(certificado));
         certificado.setValido(valido(certificado));
     }
@@ -131,6 +133,7 @@ public class CertificadoService {
 
             certificado.setCnpjCpf(getDocumentoFromCertificado(certificado, keyStore));
             certificado.setVencimento(dataValidade(certificado).toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
+            certificado.setDataHoraVencimento(dataValidade(certificado).toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
             certificado.setDiasRestantes(diasRestantes(certificado));
             certificado.setValido(valido(certificado));
 
@@ -182,10 +185,12 @@ public class CertificadoService {
             cert.setNome("(INVALIDO)" +
                                  aliasKey);
             cert.setVencimento(LocalDate.of(2000, 1, 1));
+            cert.setDataHoraVencimento(LocalDateTime.of(2000, 1, 1, 0, 0, 0));
             cert.setDiasRestantes(0L);
             cert.setValido(false);
         } else {
             cert.setVencimento(dataValidade.toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
+            cert.setDataHoraVencimento(dataValidade.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
             cert.setDiasRestantes(diasRestantes(cert));
             cert.setValido(valido(cert));
         }


### PR DESCRIPTION
Ela retorna um LocalDateTime com data e hora do vencimento do certificado!

Grande Samuel, em um dos meus projetos eu precisei a hora de vencimento do certificado, fiz essa simples modificação no projeto, eu poderia ter alterado o vencimento para LocalDateTime mais não sei se atrapalharia o resto da galera, então criei um novo campo!

Se possível incluir essa modificação no seu projeto.

Obrigado!