### PR TITLE
Tratamento de certificados na camada TLS/SSL em multithreading

### DIFF
--- a/src/main/java/br/com/swconsultoria/certificado/Certificado.java
+++ b/src/main/java/br/com/swconsultoria/certificado/Certificado.java
@@ -32,9 +32,11 @@ public class Certificado {
     private String sslProtocol;
     private BigInteger numeroSerie;
     private Provider provider;
+    private boolean modoAntigoSSL;
 
     public Certificado() {
         this.setSslProtocol(TLSV_1_2);
+        this.setModoAntigoSSL(true); //TODO Temporariamente o padrão será true, até validação do Bruno S.
     }
 
     @Override

--- a/src/main/java/br/com/swconsultoria/certificado/Certificado.java
+++ b/src/main/java/br/com/swconsultoria/certificado/Certificado.java
@@ -32,11 +32,11 @@ public class Certificado {
     private String sslProtocol;
     private BigInteger numeroSerie;
     private Provider provider;
-    private boolean modoAntigoSSL;
+    private boolean isModoMultithreading;
 
     public Certificado() {
         this.setSslProtocol(TLSV_1_2);
-        this.setModoAntigoSSL(true); //TODO Temporariamente o padrão será true, até validação do Bruno S.
+        this.setModoMultithreading(false);
     }
 
     @Override

--- a/src/main/java/br/com/swconsultoria/certificado/CertificadoService.java
+++ b/src/main/java/br/com/swconsultoria/certificado/CertificadoService.java
@@ -36,12 +36,27 @@ public class CertificadoService {
         inicializaCertificado(certificado, CertificadoService.class.getResourceAsStream("/cacert"));
     }
 
+    /**
+     * 
+     * <p>Inicializa o certificado para a conexão SSL/TLS.</p>
+     * <p><b>Importante: </b>Quando NÃO estiver com o modo multithreading ativado (certificado.isModoMultithreading())
+     * será registrado e utilizado um único certificado em todas as conexões até a próxima chamada à
+     * {@link #inicializaCertificado(Certificado, InputStream)}. É o modo antigo e padrão da biblioteca.</p>
+     * <p>Quando estiver com o modo multithreading ativo o consumidor deverá obter um
+     * {@link org.apache.commons.httpclient.HttpClient} com protocolo e certificado exclusivos para ele usando o 
+     * método {@link #getHttpsClient(Certificado, String, InputStream)}</p>
+     *
+     * @param certificado {@link Certificado} a ser utilizado na conexão.
+     * @param cacert  {@link java.io.InputStream} contendo o cacert
+     * @throws CertificadoException
+     */
+    
     public static void inicializaCertificado(Certificado certificado, InputStream cacert) throws CertificadoException {
         if (certificado == null) {
             throw new IllegalArgumentException(CERTIFICADO_NAO_PODE_SER_NULO);
         }
 
-        if (certificado.isModoAntigoSSL()) {
+        if (!certificado.isModoMultithreading()) {
             Protocol.registerProtocol("https", getProtocoloCertificado(certificado, cacert));
         }
 
@@ -286,8 +301,6 @@ public class CertificadoService {
         }
     }
 
-
-    //FIXME Validar Samuel: Talvez não seja aqui o melhor local, coloquei inicialmente porque é acessível de todos que consomem a lib de certificado.
     /**
      * Utiliza cacert default da biblioteca.
      * @see #getHttpsClient(Certificado, String, InputStream)
@@ -298,7 +311,7 @@ public class CertificadoService {
 
     /**
      * <p>Utilizar o {@link org.apache.commons.httpclient.HttpClient} gerado nesse método para evitar conflitos de
-     * certificados nas conexões HTTPS/TLS/SSL, especialmente em ambientes multithread.</p>
+     * certificados nas conexões HTTPS/TLS/SSL, especialmente em ambientes multithreading.</p>
      *
      * <p>O consumidor desse método deverá usar esse cliente no stub desejado</p>
      * exemplo:

--- a/src/test/java/br/com/swconsultoria/certificado/CertificadoServiceTest.java
+++ b/src/test/java/br/com/swconsultoria/certificado/CertificadoServiceTest.java
@@ -4,12 +4,9 @@ import br.com.swconsultoria.certificado.exception.CertificadoException;
 import br.com.swconsultoria.certificado.util.DocumentoUtil;
 import mockit.Mock;
 import mockit.MockUp;
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.protocol.Protocol;
 import org.apache.commons.httpclient.protocol.ProtocolSocketFactory;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.FileNotFoundException;
@@ -33,11 +30,11 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class CertificadoServiceTest {
 
-    private final String CERTIFICADO_CPF = "NaoUsar_CPF.pfx";
-    private final String CERTIFICADO_CNPJ = "NaoUsar_CNPJ.pfx";
-    private final String CPF = "99999999999";
-    private final String CNPJ = "99999999999999";
-    private final String SENHA = "123456";
+    private static final String CERTIFICADO_CPF = "NaoUsar_CPF.pfx";
+    private static final String CERTIFICADO_CNPJ = "NaoUsar_CNPJ.pfx";
+    private static final String CPF = "99999999999";
+    private static final String CNPJ = "99999999999999";
+    private static final String SENHA = "123456";
 
     @Test
     void certificadoPfxParametroNull() {
@@ -178,10 +175,7 @@ class CertificadoServiceTest {
     }
 
     @Test
-    void inicaConfiguracoesParametrosNull() throws IOException, CertificadoException {
-
-        InputStream cacert = CertificadoServiceTest.class.getResourceAsStream("cacert");
-        Certificado certificado = CertificadoService.certificadoPfx(CERTIFICADO_CNPJ, SENHA);
+    void inicaConfiguracoesParametrosNull() {
 
         //Certificado Null
         Assertions.assertThrows(IllegalArgumentException.class, () ->
@@ -216,13 +210,13 @@ class CertificadoServiceTest {
     /**
      * <p>Testa a compatibilidade com consumidores "antigos", que ainda não estão no "novo modelo" de controle do
      * certificado nas conexões TLS/SSL. Isso permitirá uma "migração gradual" dos consumidores.</p>
-     * Por padrão será utilizado o novo modo, cada consumidor irá precisar explicitamente escolher o "modo antigo SSL",
-     * caso deseje.
+     * </p>Por padrão será utilizado o modo antigo, cada consumidor irá precisar explicitamente escolher o
+     * "modo multithreading", caso deseje.<p>
      */
     @Test
-    void compatibilidadeComModoAntigoSSL() throws FileNotFoundException, CertificadoException {
+    void compatibilidadeModoMultithreadingDesativado() throws FileNotFoundException, CertificadoException {
         Certificado certificado = CertificadoService.certificadoPfx(CERTIFICADO_CPF, SENHA);
-        certificado.setModoAntigoSSL(true);
+        certificado.setModoMultithreading(false);
         CertificadoService.inicializaCertificado(certificado);
 
         String alias = getHttpsProtocoloAlias("https");

--- a/src/test/java/br/com/swconsultoria/certificado/CertificadoServiceTest.java
+++ b/src/test/java/br/com/swconsultoria/certificado/CertificadoServiceTest.java
@@ -4,12 +4,18 @@ import br.com.swconsultoria.certificado.exception.CertificadoException;
 import br.com.swconsultoria.certificado.util.DocumentoUtil;
 import mockit.Mock;
 import mockit.MockUp;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.commons.httpclient.protocol.Protocol;
+import org.apache.commons.httpclient.protocol.ProtocolSocketFactory;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Field;
 import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -207,4 +213,34 @@ class CertificadoServiceTest {
 
     }
 
+    /**
+     * <p>Testa a compatibilidade com consumidores "antigos", que ainda não estão no "novo modelo" de controle do
+     * certificado nas conexões TLS/SSL. Isso permitirá uma "migração gradual" dos consumidores.</p>
+     * Por padrão será utilizado o novo modo, cada consumidor irá precisar explicitamente escolher o "modo antigo SSL",
+     * caso deseje.
+     */
+    @Test
+    void compatibilidadeComModoAntigoSSL() throws FileNotFoundException, CertificadoException {
+        Certificado certificado = CertificadoService.certificadoPfx(CERTIFICADO_CPF, SENHA);
+        certificado.setModoAntigoSSL(true);
+        CertificadoService.inicializaCertificado(certificado);
+
+        String alias = getHttpsProtocoloAlias("https");
+
+        assertEquals("certificado cpf teste", alias);
+    }
+
+    private String getHttpsProtocoloAlias(String protocolId)  {
+        try {
+            Protocol registeredProtocol = Protocol.getProtocol(protocolId);
+            ProtocolSocketFactory factory = registeredProtocol.getSocketFactory();
+
+            Class<?> clazz = factory.getClass();
+            Field getAliasField = clazz.getDeclaredField("alias");
+            getAliasField.setAccessible(true);
+            return (String) getAliasField.get(factory);
+        } catch (Exception e) {
+            return null;
+        }
+    }
 }


### PR DESCRIPTION
@Samuel-Oliveira 
Conforme comentado no Discord, esse PR é ainda um _Draft_ para ver se a abordagem será aceita, ou ainda para eventuais ajustes nela.

Ver também o [PR Draft #293 no java_nfe](https://github.com/Samuel-Oliveira/Java_NFe/pull/293), implementei apenas para `Status` e `DistribuicaoDFe`, no java_nfe está como ficaria a nova abordagem nos consumidores.  

**Resumindo a abordagem:**  
No modelo antigo o certificado é setado na conexão HTTPS de forma "global", afetando todas as execuções.
Como ele "seta" o certificado bem proximo da execução do stub, a maior parte das vezes o problema não é percebido, só é percebido que alguma outra thread altera a conexão globalmente antes que seja executado o stub.

No modelo novo, é criado e utilizado um client e protocolo específicos para o certificado esperado.
